### PR TITLE
日付がチラつくのを治す

### DIFF
--- a/components/organisms/BlogPost/BlogPost.tsx
+++ b/components/organisms/BlogPost/BlogPost.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs'
 import Link from 'next/link'
 import { FC } from 'react'
 import styles from './BlogPost.module.scss'
@@ -6,14 +5,14 @@ import styles from './BlogPost.module.scss'
 type Props = {
   id: string
   title: string
-  createdAt: string
+  publishedAt: string
 }
 
-const BlogPost: FC<Props> = ({ id, title, createdAt }) => {
+const BlogPost: FC<Props> = ({ id, title, publishedAt }) => {
   return (
     <article className={styles['post']}>
       <Link href={`/blog/${id}`}>
-        <time className={styles['time']}>{dayjs(createdAt).format('YYYY-MM-DD')}</time>
+        <time className={styles['time']}>{publishedAt}</time>
         <h2 className={styles['title']}>{title}</h2>
       </Link>
     </article>

--- a/components/organisms/BlogPostContent/BlogPostContent.tsx
+++ b/components/organisms/BlogPostContent/BlogPostContent.tsx
@@ -6,18 +6,18 @@ import 'zenn-content-css'
 
 type Props = {
   title: string
-  createdAt: string
+  publishedAt: string
   body: string
 }
 
-const BlogPostContent: FC<Props> = ({ title, createdAt, body }) => {
+const BlogPostContent: FC<Props> = ({ title, publishedAt, body }) => {
   const html = markdownHtml(body)
 
   return (
     <article className={styles['article']}>
       <div className={styles['content']}>
         <h2 className={styles['title']}>{title}</h2>
-        <time className={styles['time']}>{dayjs(createdAt).format('YYYY-MM-DD')}</time>
+        <time className={styles['time']}>{publishedAt}</time>
         <div
           className={`${styles['body']} znc`}
           dangerouslySetInnerHTML={{

--- a/components/organisms/BlogPostContent/BlogPostContent.tsx
+++ b/components/organisms/BlogPostContent/BlogPostContent.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs'
 import { FC } from 'react'
 import markdownHtml from 'zenn-markdown-html'
 import styles from './BlogPostContent.module.scss'

--- a/components/pages/BlogPage/BlogPage.tsx
+++ b/components/pages/BlogPage/BlogPage.tsx
@@ -12,7 +12,7 @@ const BlogPage: FC<Props> = ({ posts }) => {
   return (
     <section className={styles['posts']}>
       {posts.map((post: Entry<IPostFields>) => (
-        <BlogPost id={post.sys.id} title={post.fields.title} createdAt={post.sys.createdAt} key={post.sys.id} />
+        <BlogPost id={post.sys.id} title={post.fields.title} publishedAt={post.fields.publishedAt} key={post.sys.id} />
       ))}
     </section>
   )

--- a/components/pages/BlogPostPage/BlogPostPage.tsx
+++ b/components/pages/BlogPostPage/BlogPostPage.tsx
@@ -11,7 +11,7 @@ type Props = {
 const BlogPage: FC<Props> = ({ post }) => {
   return (
     <section className={styles['posts']}>
-      <BlogPostContent title={post.fields.title} createdAt={post.sys.createdAt} body={post.fields.body} />
+      <BlogPostContent title={post.fields.title} publishedAt={post.fields.publishedAt} body={post.fields.body} />
     </section>
   )
 }

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -4,6 +4,7 @@ import { Entry } from 'contentful'
 export interface IPostFields {
   title: string
   body: string
+  publishedAt: string
 }
 
 export interface IPost extends Entry<IPostFields> {

--- a/lib/feed.ts
+++ b/lib/feed.ts
@@ -22,7 +22,7 @@ export const generateEntryRssXml = (entries: Entry<IPostFields>[], path: string)
           },
         },
       ],
-      date: new Date(entry.sys.createdAt),
+      date: new Date(entry.fields.publishedAt),
       url: `${process.env.BASE_URL}${path}/${entry.sys.id}`,
     })
   })

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,14 @@
 import '../styles/globals.scss'
 import '../styles/reset.scss'
+import dayjs from 'dayjs'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
 import type { AppProps } from 'next/app'
 import { useEffect } from 'react'
+
+dayjs.extend(timezone)
+dayjs.extend(utc)
+dayjs.tz.setDefault('Asia/Tokyo')
 
 export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {

--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -1,5 +1,6 @@
 import { ParsedUrlQuery } from 'node:querystring'
 import { Entry, EntryCollection } from 'contentful'
+import dayjs from 'dayjs'
 import type { NextPage, GetStaticProps, GetStaticPaths } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
@@ -36,6 +37,8 @@ interface Params extends ParsedUrlQuery {
 
 export const getStaticProps: GetStaticProps<Props, Params> = async ({ params }) => {
   const item = await getPostEntry(params!.id)
+  item.fields.publishedAt = dayjs(item.fields.publishedAt).tz('Asia/Tokyo').format('YYYY-MM-DD')
+
   return {
     props: {
       post: item,

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,6 +1,6 @@
 import { Entry, EntryCollection } from 'contentful'
+import dayjs from 'dayjs'
 import type { NextPage, GetStaticProps } from 'next'
-import Head from 'next/head'
 import DefaultLayout from 'components/layout/Default'
 import BlogPageContainer from 'components/pages/BlogPage'
 import { buildClient, IPostFields } from 'lib/contentful'
@@ -14,6 +14,11 @@ export const getStaticProps: GetStaticProps = async () => {
     order: '-sys.createdAt',
   })
   publishRssXml(items, '/blog')
+  items.map(
+    (item: Entry<IPostFields>) =>
+      (item.fields.publishedAt = dayjs(item.fields.publishedAt).tz('Asia/Tokyo').format('YYYY-MM-DD'))
+  )
+
   return {
     props: { posts: items },
   }

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -11,7 +11,7 @@ const client = buildClient()
 export const getStaticProps: GetStaticProps = async () => {
   const { items }: EntryCollection<IPostFields> = await client.getEntries({
     content_type: 'post',
-    order: '-sys.createdAt',
+    order: '-fields.publishedAt',
   })
   publishRssXml(items, '/blog')
   items.map(


### PR DESCRIPTION
dayjs formatをCSでやっていたのが問題
- data fetchしたとき(build時に)formatするようにする
- sys.createdAtはread onlyなのでpublishedAtを生やす
- ついでにpublishedAtで全部見るようにした